### PR TITLE
Fix breaking change from minio update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ gym==0.12.5
 bokeh==1.0.4
 kubernetes>=8.0.0b1,<=8.0.1
 redis>=2.10.6
-minio>=4.0.5,<7.0.0
+minio>=4.0.5
 pytest>=3.8.2
 psutil>=5.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ gym==0.12.5
 bokeh==1.0.4
 kubernetes>=8.0.0b1,<=8.0.1
 redis>=2.10.6
-minio>=4.0.5
+minio>=4.0.5,<7.0.0
 pytest>=3.8.2
 psutil>=5.5.0

--- a/rl_coach/data_stores/s3_data_store.py
+++ b/rl_coach/data_stores/s3_data_store.py
@@ -18,7 +18,7 @@
 from rl_coach.data_stores.data_store import DataStoreParameters
 from rl_coach.data_stores.checkpoint_data_store import CheckpointDataStore
 from minio import Minio
-from minio.error import ResponseError
+from minio.error import S3Error
 from configparser import ConfigParser, Error
 from rl_coach.checkpoint import CheckpointStateFile
 from rl_coach.data_stores.data_store import SyncFiles
@@ -134,7 +134,7 @@ class S3DataStore(CheckpointDataStore):
                 for filename in os.listdir(os.path.join(self.params.expt_dir, 'gifs')):
                         self.mc.fput_object(self.params.bucket_name, filename, os.path.join(self.params.expt_dir, 'gifs', filename))
 
-        except ResponseError as e:
+        except S3Error as e:
             print("Got exception: %s\n while saving to S3", e)
 
     def load_from_store(self):
@@ -190,7 +190,7 @@ class S3DataStore(CheckpointDataStore):
                     if not os.path.exists(filename):
                         self.mc.fget_object(obj.bucket_name, obj.object_name, filename)
 
-        except ResponseError as e:
+        except S3Error as e:
             print("Got exception: %s\n while loading from S3", e)
 
     def setup_checkpoint_dir(self, crd=None):


### PR DESCRIPTION
They removed the `ResponseError` class
Limit version for now to avoid crashes (in CI as well)