### PR TITLE
Fix Rust compiler build error (Kubernetes dependency)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ aliases:
     run:
       name: Prepare aws cli
       command: |
+        sudo pip install --upgrade pip
         sudo pip install awscli pytest kubernetes==8.0.0b1
 
         $(aws ecr get-login --no-include-email --region us-west-2)


### PR DESCRIPTION
The Python Kubernetes client depends on the `cryptography` package, which apparently requires the Rust compiler, and it currently fails building with the message below (see also [here](https://cryptography.io/en/latest/faq.html#installing-cryptography-fails-with-error-can-not-find-rust-compiler)).

Trying the suggested step 1 first.

```
    running build_rust
    
        =============================DEBUG ASSISTANCE=============================
        If you are seeing a compilation error please try the following steps to
        successfully install cryptography:
        1) Upgrade to the latest pip and try again. This will fix errors for most
           users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
        2) Read https://cryptography.io/en/latest/installation.html for specific
           instructions for your platform.
        3) Check our frequently asked questions for more information:
           https://cryptography.io/en/latest/faq.html
        4) Ensure you have a recent Rust toolchain installed.
        =============================DEBUG ASSISTANCE=============================
    
    error: Can not find Rust compiler
```