### PR TITLE
Update setuptools

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -43,7 +43,7 @@ RUN ln -s /usr/bin/python3.6 /usr/bin/python3
 # Install Pip Requirements #
 ############################
 RUN pip3 install --upgrade pip
-RUN pip3 install setuptools==39.1.0 && pip3 install pytest && pip3 install pytest-xdist
+RUN pip3 install setuptools==56.1.0 && pip3 install pytest && pip3 install pytest-xdist
 
 RUN curl -o /usr/local/bin/patchelf https://s3-us-west-2.amazonaws.com/openai-sci-artifacts/manual-builds/patchelf_0.9_amd64.elf \
     && chmod +x /usr/local/bin/patchelf


### PR DESCRIPTION
This solves the vizdoom installation error in the `build_doom_env` CI flow.

See here:
https://app.circleci.com/pipelines/github/IntelLabs/coach/1740/workflows/5da1feb8-8972-4c79-a847-560a72a1e639